### PR TITLE
[fix]ポイントと優先権交換をダミーに調整

### DIFF
--- a/frontend/app/points/page.tsx
+++ b/frontend/app/points/page.tsx
@@ -7,7 +7,10 @@ import { MobileNav } from "@/components/layout/mobile-nav"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Gift, History, Clock } from "lucide-react"
-import { getUserPoints, spendPoints, getPointHistory } from "@/actions/points"
+// import { getUserPoints, spendPoints, getPointHistory } from "@/actions/points"
+// ダミー用
+import { getUserPoints, spendPoints, getPointHistory } from "@/lib/api-client"
+
 
 interface PointTransaction {
   id: string
@@ -79,21 +82,32 @@ export default function PointsPage() {
   // ポイント情報と履歴をロード
   useEffect(() => {
     const loadData = async () => {
-      const [points, history] = await Promise.all([getUserPoints(userId), getPointHistory(userId)])
+      const [points, history] = await Promise.all([getUserPoints("",userId), getPointHistory(userId)])
       setCurrentUserPoints(points)
       setUserPointHistory(history)
     }
     loadData()
   }, [userId])
 
+
+
+
+
+
   const handleExchange = async (itemId: string, points: number, itemName: string) => {
     setIsPending(true)
     setExchangeMessage("")
-
+  
     const itemToExchange = exchangeItems.find((item) => item.id === itemId)
-    if (itemToExchange?.limitType === "once_per_family") {
+    if (!itemToExchange) {
+      setExchangeMessage("交換対象が見つかりませんでした。")
+      setIsPending(false)
+      return
+    }
+  
+    if (itemToExchange.limitType === "once_per_family") {
       const hasExchanged = userPointHistory.some(
-        (tx) => tx.type === "spend" && tx.description.includes(itemToExchange.name),
+        (tx) => tx.type === "spend" && tx.description.includes(itemToExchange.name)
       )
       if (hasExchanged) {
         setExchangeMessage("この景品は1家庭1回までしか交換できません。")
@@ -101,16 +115,72 @@ export default function PointsPage() {
         return
       }
     }
-
-    const result = await spendPoints(userId, points, `${itemName}と交換`)
+  
+    // ✅ ============ ダミーで即成功 =============
+    const result = { success: true, message: `${itemToExchange.name}と交換が完了しました！` }
+  
+    // ✅ 【本来のAPI呼び出し版（残す）】
+    // const result = await spendPoints(userId, points, `${itemName}と交換`)
+  
     setExchangeMessage(result.message)
+  
     if (result.success) {
-      const [updatedPoints, updatedHistory] = await Promise.all([getUserPoints(userId), getPointHistory(userId)])
-      setCurrentUserPoints(updatedPoints)
-      setUserPointHistory(updatedHistory)
+      // ✅ 【ダミー】ポイントを引いて履歴を足す
+      setCurrentUserPoints(currentUserPoints - itemToExchange.pointsRequired)
+      setUserPointHistory([
+        ...userPointHistory,
+        {
+          id: String(Date.now()),
+          userId: userId,
+          type: "spend",
+          amount: itemToExchange.pointsRequired,
+          description: `${itemToExchange.name}と交換`,
+          date: new Date().toISOString(),
+        },
+      ])
+  
+      // ✅ 【本来のAPI連携で履歴・残高を再取得する版（残す）】
+      // const [updatedPoints, updatedHistory] = await Promise.all([
+      //   getUserPoints(userId),
+      //   getPointHistory(userId)
+      // ])
+      // setCurrentUserPoints(updatedPoints)
+      // setUserPointHistory(updatedHistory)
     }
+  
     setIsPending(false)
   }
+  
+
+
+
+
+
+  // const handleExchange = async (itemId: string, points: number, itemName: string) => {
+  //   setIsPending(true)
+  //   setExchangeMessage("")
+
+  //   const itemToExchange = exchangeItems.find((item) => item.id === itemId)
+  //   if (itemToExchange?.limitType === "once_per_family") {
+  //     const hasExchanged = userPointHistory.some(
+  //       (tx) => tx.type === "spend" && tx.description.includes(itemToExchange.name),
+  //     )
+  //     if (hasExchanged) {
+  //       setExchangeMessage("この景品は1家庭1回までしか交換できません。")
+  //       setIsPending(false)
+  //       return
+  //     }
+  //   }
+
+  //   const result = await spendPoints(userId, points, `${itemName}と交換`)
+  //   setExchangeMessage(result.message)
+  //    if (result.success) {
+  //     const [updatedPoints, updatedHistory] = await Promise.all([getUserPoints(userId), getPointHistory(userId)])
+  //     setCurrentUserPoints(updatedPoints)
+  //     setUserPointHistory(updatedHistory)
+  //   }
+  //   setIsPending(false)
+  // }
 
   const isExchangeDisabled = (item: (typeof exchangeItems)[0]) => {
     if (isPending || currentUserPoints < item.pointsRequired) {

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -15,11 +15,69 @@ export type Participant = {
     point: number
     applicationsCount: number 
   }
+
+  export type PointTransaction = {
+    id: string
+    userId: string
+    type: "earn" | "spend"
+    amount: number
+    description: string
+    date: string
+  }
   
+  
+  // イベント一覧
   export async function getEvents(): Promise<Event[]> {
     const res = await fetch('http://localhost:4000/api/events', { cache: 'no-store' })
     if (!res.ok) throw new Error('イベント一覧取得失敗')
     return await res.json() // ← もう events でラップされてないからそのまま
   }
   
+
+  // ポイント確認
+  export async function getUserPoints(token: string, userId: string): Promise<number> {
+    console.log("DEBUG getUserPoints dummy:", token, userId)
+    return 250
+  }
+    
+
+    // const res = await fetch("http://localhost:4000/api/points", {
+    //   cache: "no-store",
+    //   headers: {
+    //     Authorization: `Bearer ${token}`,
+    //   },
+    // })
+    // if (!res.ok) throw new Error("ポイント取得失敗")
+    // const data = await res.json()
+    // return data.balance
+  // }
+  
+  export async function getPointHistory(userId: string): Promise<PointTransaction[]> {
+    console.log("DEBUG getPointHistory dummy:", userId)
+    return [] // 仮で空配列を返す
+  }
+  
+  // export async function getPointHistory(userId: string, token: string): Promise<PointTransaction[]> {
+  //   const res = await fetch(`http://localhost:4000/api/points/${userId}/history`, {
+  //     cache: "no-store",
+  //     headers: {
+  //       Authorization: `Bearer ${token}`,
+  //     },
+  //   })
+  //   if (!res.ok) throw new Error("履歴取得失敗")
+  //   return res.json()
+  // }
+  
+  export async function spendPoints(rewardId: string, token: string) {
+    const res = await fetch(`http://localhost:4000/api/rewards/${rewardId}/exchange`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({}),
+    })
+    if (!res.ok) return { success: false, message: "交換に失敗しました" }
+    return { success: true, message: "交換が完了しました！" }
+  }
   


### PR DESCRIPTION
ポイント画面(`frontend/app/points/page.tsx`) と API クライアント(`frontend/lib/api-client.ts`) のみ修正。
本来のバックエンド連携は未反映で、フロント側のみダミーでポイント減算できるように調整。